### PR TITLE
Add !important to .hide-display to override native styling

### DIFF
--- a/src/content.css
+++ b/src/content.css
@@ -1,3 +1,3 @@
 .hide-display {
-    display: none;
+    display: none !important;
 }


### PR DESCRIPTION
The extension is currently not working. This is because the `.hide-display` class gets overridden by YouTube. `!important` fixes this issue.